### PR TITLE
Fixed pod error as reported by CPANTS.

### DIFF
--- a/lib/Device/Firewall/PaloAlto/Op.pm
+++ b/lib/Device/Firewall/PaloAlto/Op.pm
@@ -72,7 +72,7 @@ sub interfaces {
     return Device::Firewall::PaloAlto::Op::Interfaces->_new( $self->_send_op_cmd('show interface', 'all') );
 }
 
-=head2 
+=head2 arp_table
 
     my $arp = $fw->op->arp_table();
 


### PR DESCRIPTION
Hi @gregfoletta 

Please review the PR.
https://cpants.cpanauthors.org/release/PUGLET/Device-Firewall-PaloAlto-0.1.2

          Error: *** ERROR: empty =head2 at line 153 in file Device-Firewall-PaloAlto-0.1.2/lib/Device/Firewall/PaloAlto/Op.pm

Many Thanks.
Best Regards,
Mohammad S Anwar